### PR TITLE
Simple workaround for default export of cli.js

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,2 +1,9 @@
 import jsonImporter from './index';
 export default jsonImporter();
+
+// Super-hacky: Override Babel's transpiled export to provide both
+// a default CommonJS export and named exports.
+// Fixes: https://github.com/Updater/node-sass-json-importer/issues/32
+// TODO: Remove in 3.0.0. Upgrade to Babel6.
+module.exports = exports.default;
+Object.keys(exports).forEach(key => module.exports[key] = exports[key]);


### PR DESCRIPTION
This fix adds the same workaround to the `cli.js` as already present in `index.js`. An alternative would be to use https://www.npmjs.com/package/babel-plugin-add-module-exports to automatically adjust the exports.

fixes #85 